### PR TITLE
feat: Implement universal debug mode for twlayout-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,25 @@ This will build the CSS using Tailwind and open the index.html file in your brow
 - Tailwind CSS v4.1.5
 - PostCSS
 - Autoprefixer
+
+## Universal Debug Mode
+
+The `twlayout-plugin/scripts/universal-debug.js` script provides a way to apply the plugin's debug mode styling (defined in `twlayout-plugin/styles/decoration.css`) to any HTML page, not just the main `demo.html`. This is useful for testing the grid layout on different HTML structures or standalone components.
+
+### How to Use
+
+1.  Include the script in your HTML file:
+    ```html
+    <script type="module" src="path/to/twlayout-plugin/scripts/universal-debug.js"></script>
+    ```
+    Ensure you replace `path/to/` with the correct relative path from your HTML file to the `twlayout-plugin` directory. For example, if your HTML file is in `workfiles/`, the path would be `../twlayout-plugin/scripts/universal-debug.js`.
+
+2.  The script will automatically:
+    *   Load the necessary `decoration.css` stylesheet into the page's `<head>`.
+    *   Inject a "Debug Mode" toggle switch (a checkbox and label) onto the page, typically at the bottom.
+
+3.  Use the toggle switch to turn debug mode on or off. The state is saved in `localStorage`, so your preference will be remembered across page loads.
+
+### Scope of Debug Styles
+
+The debug styles, as defined in `decoration.css`, primarily target elements with `.rack` and `.rail` classes and their direct children (columns). It will visually outline these grid components, show padding, gaps, and other layout-related visual cues. It may not provide detailed debug information for elements outside of this primary scope.

--- a/twlayout-plugin/demo/demo.js
+++ b/twlayout-plugin/demo/demo.js
@@ -3,7 +3,7 @@
  * These scripts are specific to the demo page and not part of the core grid system
  */
 
-import { SYSTEM, VIEWPORTS, RACK_COLUMNS, RAIL_COLUMNS, GRID_COLORS } from '../scripts/grid-config.js';
+import { VIEWPORTS, RACK_COLUMNS, RAIL_COLUMNS, GRID_COLORS } from '../scripts/grid-config.js';
 
 // Toggle between rack and rail containers
 document.getElementById('rack-toggle').addEventListener('change', function() {
@@ -21,24 +21,6 @@ document.getElementById('rail-toggle').addEventListener('change', function() {
     updateColumnInfo();
   }
 });
-
-// Debug mode toggle
-document.getElementById('debug-mode-toggle').addEventListener('click', function() {
-  this.checked = !this.checked;
-  document.body.classList.toggle('debug-mode');
-  
-  // Save debug mode state to localStorage
-  localStorage.setItem(SYSTEM.DEBUG_MODE_KEY, document.body.classList.contains('debug-mode') ? 'enabled' : 'disabled');
-});
-
-// Initialize debug mode from localStorage if available
-function initDebugMode() {
-  const debugModeState = localStorage.getItem(SYSTEM.DEBUG_MODE_KEY);
-  if (debugModeState === 'enabled') {
-    document.getElementById('debug-mode-toggle').checked = true;
-    document.body.classList.add('debug-mode');
-  }
-}
 
 // Function to get current breakpoint
 function getCurrentBreakpoint() {
@@ -160,7 +142,6 @@ document.addEventListener('DOMContentLoaded', function() {
 
 // Call both update functions on load and resize
 window.addEventListener('load', function() {
-  initDebugMode(); // Initialize debug mode from localStorage
   updateColumnInfo();
   updateOffsetInfo();
 });

--- a/twlayout-plugin/scripts/universal-debug.js
+++ b/twlayout-plugin/scripts/universal-debug.js
@@ -1,0 +1,103 @@
+import { SYSTEM } from './grid-config.js';
+
+(function() {
+  try {
+    // Create a new <link> element
+    var linkElement = document.createElement('link');
+
+    // Set the href attribute
+    // Assuming universal-debug.js is in scripts/ and decoration.css is in styles/
+    // Adjust the path if the directory structure is different.
+    linkElement.href = '../styles/decoration.css';
+
+    // Set the rel attribute
+    linkElement.rel = 'stylesheet';
+
+    // Append the <link> element to the <head>
+    var headElement = document.head || document.getElementsByTagName('head')[0];
+    if (headElement) {
+      headElement.appendChild(linkElement);
+    } else {
+      console.error('Could not find the <head> element to append the stylesheet.');
+    }
+  } catch (error) {
+    console.error('Error while adding stylesheet: ', error);
+  }
+
+  try {
+    // Create the div container
+    var divElement = document.createElement('div');
+    divElement.className = 'debug-toggle-container';
+
+    // Create the checkbox input element
+    var inputElement = document.createElement('input');
+    inputElement.type = 'checkbox';
+    inputElement.id = 'debug-mode-toggle';
+
+    // Create the label element
+    var labelElement = document.createElement('label');
+    labelElement.htmlFor = 'debug-mode-toggle';
+    labelElement.className = 'debug-toggle-label';
+    labelElement.textContent = 'Debug Mode';
+
+    // Append input and label to the div
+    divElement.appendChild(inputElement);
+    divElement.appendChild(labelElement);
+
+    // Append the div to the body
+    var bodyElement = document.body || document.getElementsByTagName('body')[0];
+    if (bodyElement) {
+      bodyElement.appendChild(divElement);
+    } else {
+      console.error('Could not find the <body> element to append the debug toggle.');
+    }
+  } catch (error) {
+    console.error('Error while adding debug toggle: ', error);
+  }
+
+  try {
+    // const DEBUG_MODE_STORAGE_KEY = 'twLayoutDebugMode'; // Replaced by SYSTEM.DEBUG_MODE_KEY
+    const debugToggleCheckbox = document.getElementById('debug-mode-toggle');
+    const body = document.body;
+
+    if (!SYSTEM || typeof SYSTEM.DEBUG_MODE_KEY === 'undefined') {
+      console.error('SYSTEM.DEBUG_MODE_KEY is not defined. Check grid-config.js and import.');
+      return;
+    }
+    
+    if (!debugToggleCheckbox) {
+      console.error('Debug mode checkbox not found.');
+      return;
+    }
+
+    // Event Listener for checkbox change
+    debugToggleCheckbox.addEventListener('change', function() {
+      if (this.checked) {
+        body.classList.add('debug-mode');
+        localStorage.setItem(SYSTEM.DEBUG_MODE_KEY, 'enabled');
+      } else {
+        body.classList.remove('debug-mode');
+        localStorage.setItem(SYSTEM.DEBUG_MODE_KEY, 'disabled');
+      }
+    });
+
+    // Initialization Function
+    function initDebugMode() {
+      const savedState = localStorage.getItem(SYSTEM.DEBUG_MODE_KEY);
+      if (savedState === 'enabled') {
+        debugToggleCheckbox.checked = true;
+        body.classList.add('debug-mode');
+      } else {
+        // Optional: ensure it's disabled if not explicitly enabled or if value is 'disabled'
+        debugToggleCheckbox.checked = false;
+        body.classList.remove('debug-mode');
+      }
+    }
+
+    // Call Initialization
+    initDebugMode();
+
+  } catch (error) {
+    console.error('Error in debug mode logic: ', error);
+  }
+})();

--- a/workfiles/demo.html
+++ b/workfiles/demo.html
@@ -5,17 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Rack & Rail Grid System</title>
   <link href="../dist/output.css" rel="stylesheet">
-  <link href="../twlayout-plugin/styles/decoration.css" rel="stylesheet">
   <link href="../twlayout-plugin/styles/layout.css" rel="stylesheet">
 </head>
 <body>
   <div class="viewport-info">
     Viewport: <span id="viewport-size">Loading...</span>
-  </div>
-  
-  <div class="debug-toggle-container">
-    <input type="checkbox" id="debug-mode-toggle">
-    <label for="debug-mode-toggle" class="debug-toggle-label">Debug Mode</label>
   </div>
   
   <div class="page-wrapper">
@@ -510,6 +504,7 @@
     </div>
   </section>
   
+  <script type="module" src="../twlayout-plugin/scripts/universal-debug.js"></script>
   <script type="module" src="../twlayout-plugin/demo/demo.js"></script>
 </body>
 </html>

--- a/workfiles/test-debug.html
+++ b/workfiles/test-debug.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Test Universal Debug</title>
+    <script type="module" src="../twlayout-plugin/scripts/universal-debug.js"></script>
+    <style>
+        /* Basic styling for visibility */
+        div { padding: 10px; margin: 5px; border: 1px solid #ccc; }
+        .rack { border-color: blue; }
+        .rail { border-color: green; }
+        .col-4 { background-color: #f0f0f0; }
+    </style>
+</head>
+<body>
+    <h1>Universal Debug Test Page</h1>
+    <p>This page only includes universal-debug.js.</p>
+
+    <div class="rack">
+        I am a rack.
+        <div class="col-4">Rack Column 1</div>
+        <div class="col-4">Rack Column 2</div>
+        <div class="col-4">Rack Column 3</div>
+    </div>
+
+    <div class="rail">
+        I am a rail.
+        <div class="col-6">Rail Column A</div>
+        <div class="col-6">Rail Column B</div>
+    </div>
+
+    <div>
+        I am a generic div.
+    </div>
+
+</body>
+</html>


### PR DESCRIPTION
Introduces `universal-debug.js`, a script that enables the twlayout-plugin's debug mode on any HTML page.

Key changes:
- `twlayout-plugin/scripts/universal-debug.js`: New script that dynamically injects `decoration.css` and the debug toggle HTML into the current page. It handles toggle functionality and persists the debug state via localStorage, using the `SYSTEM.DEBUG_MODE_KEY` from `grid-config.js`.
- `twlayout-plugin/demo/demo.js`: Refactored to remove its original debug mode logic, now handled by `universal-debug.js`.
- `workfiles/demo.html`: Updated to use `universal-debug.js` and remove hardcoded debug toggle and `decoration.css` link.
- `workfiles/test-debug.html`: New HTML file created to demonstrate and test `universal-debug.js` on a generic page.
- `README.md`: Updated to include documentation for the new universal debug mode feature and how to use it.

This change allows you to easily apply the existing debug styles (border highlights, layout overlays for .rack and .rail) to any HTML document for layout inspection, not just pages specifically built with or for the plugin's demo structure.