### PR TITLE
Refine viewport descriptions and adjust minimum width in debug mode

### DIFF
--- a/twlayout-plugin/scripts/debug-mode.js
+++ b/twlayout-plugin/scripts/debug-mode.js
@@ -101,10 +101,10 @@ import { SYSTEM, VIEWPORTS } from './grid-config.js';
   try {
     // Constants for viewport management
     const DEFAULT_VIEWPORTS = [
-      { value: 375, label: 'sm: 375px', breakpoint: 'sm', description: '375px viewport (335px available)' },
-      { value: 770, label: 'md: 770px', breakpoint: 'md', description: '770px viewport (690px available)' },
-      { value: 1450, label: 'lg: 1450px', breakpoint: 'lg', description: '1450px viewport (1386px available)' },
-      { value: 1800, label: 'xl: 1800px', breakpoint: 'xl', description: '1800px viewport (1736px available)' }
+      { value: 375, label: 'sm: 375px', breakpoint: 'sm', description: '375px (335px available)' },
+      { value: 770, label: 'md: 770px', breakpoint: 'md', description: '770px (690px available)' },
+      { value: 1450, label: 'lg: 1450px', breakpoint: 'lg', description: '1450px (1386px available)' },
+      { value: 1800, label: 'xl: 1800px', breakpoint: 'xl', description: '1800px (1736px available)' }
     ];
 
     // State management

--- a/twlayout-plugin/styles/debug-mode.css
+++ b/twlayout-plugin/styles/debug-mode.css
@@ -91,7 +91,7 @@ body.debug-mode .viewport-container.debug-only {
   position: absolute;
   bottom: 100%;
   left: 0;
-  min-width: 280px;
+  min-width: 210px;
   margin-bottom: 4px;
   background: white;
   border: 1px solid #d1d5db;


### PR DESCRIPTION
- Updated viewport descriptions in debug-mode.js for clarity by removing redundant information.
- Changed the minimum width in debug-mode.css from 280px to 210px to enhance layout flexibility.